### PR TITLE
Update for Symphony 4.x

### DIFF
--- a/assets/multilingual_checkbox_field.publish.css
+++ b/assets/multilingual_checkbox_field.publish.css
@@ -1,7 +1,0 @@
-.field-multilingual_checkbox .tab-panel{
-	overflow: hidden;
-}
-
-.field-multilingual_checkbox .invalid label {
-	color: #c31;
-}

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -31,8 +31,6 @@
 			return Symphony::Database()
 				->create(self::FIELD_TABLE)
 				->ifNotExists()
-				->charset('utf8')
-				->collate('utf8_unicode_ci')
 				->fields([
 					'id' => [
 						'type' => 'int(11)',

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -144,12 +144,17 @@
 		 * @param array $context
 		 */
 		public function dFLSavePreferences($context) {
-			if ($fields = Symphony::Database()->fetch(sprintf("SELECT `field_id` FROM `%s`", self::FIELD_TABLE))) {
+			$fields = Symphony::Database()->fetch(sprintf(
+				'SELECT `field_id` FROM `%s`',
+				self::FIELD_TABLE
+			));
+
+			if (is_array($fields) && !empty($fields)) {
 				$new_languages = $context['new_langs'];
 
 				// Foreach field check multilanguage values foreach language
 				foreach ($fields as $field) {
-					$entries_table = "tbl_entries_data_{$field["field_id"]}";
+					$entries_table = 'tbl_entries_data_'.$field["field_id"];
 
 					try {
 						$current_columns = Symphony::Database()->fetch("SHOW COLUMNS FROM `$entries_table` LIKE 'value-%';");
@@ -165,7 +170,7 @@
 					$valid_columns = array();
 
 					// Remove obsolete fields
-					if ($current_columns) {
+					if ($current_columns && !empty($current_columns)) {
 						$consolidate = $_POST['settings']['multilingual_checkbox_field']['consolidate'] === 'yes';
 
 						foreach ($current_columns as $column) {

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -70,10 +70,6 @@
 			) {
 				$page = Administration::instance()->Page;
 
-				if ($type === self::PUBLISH_HEADERS) {
-					$page->addStylesheetToHead(URL . '/extensions/multilingual_checkbox_field/assets/multilingual_checkbox_field.publish.css', 'screen');
-				}
-
 				if ($type === self::SETTINGS_HEADERS) {
 					$page->addScriptToHead(URL . '/extensions/multilingual_checkbox_field/assets/multilingual_checkbox_field.settings.js');
 				}

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -121,7 +121,7 @@
 			$group->appendChild(new XMLElement('legend', __('Multilingual Check Box')));
 
 			$label = Widget::Label(__('Consolidate entry data'));
-			$label->appendChild(Widget::Input('settings[multilingual_checkbox_field][consolidate]', 'yes', 'checkbox', array('checked' => 'checked')));
+			$label->prependChild(Widget::Input('settings[multilingual_checkbox_field][consolidate]', 'yes', 'checkbox', array('checked' => 'checked')));
 			$group->appendChild($label);
 			$group->appendChild(new XMLElement('p', __('Check this field if you want to consolidate database by <b>keeping</b> entry values of removed/old Language Driver language codes. Entry values of current language codes will not be affected.'), array('class' => 'help')));
 

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -169,7 +169,7 @@
 		 */
 		public function dFLSavePreferences($context) {
 			$fields = Symphony::Database()
-				->select('field_id')
+				->select(['field_id'])
 				->from(self::FIELD_TABLE)
 				->execute()
 				->rows();

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -26,6 +26,7 @@
 	<releases>
 		<release version="2.0.0" date="TBA" min="4.0.0" max="4.x.x" php-min="5.6.x" php-max="7.x.x">
 			- Update for Symphony 4.x
+			- Code refactoring for Database and EQFA
 		</release>
 		<release version="1.0.4" date="2017-08-22" min="2.6.x" max="2.x.x">
 			- Fix problem with default state always on

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -24,7 +24,7 @@
 	</dependencies>
 
 	<releases>
-		<release version="2.0.0" date="TBA" min="4.0.0" max="4.x.x">
+		<release version="2.0.0" date="TBA" min="4.0.0" max="4.x.x" php-min="5.6.x" php-max="7.x.x">
 			- Update for Symphony 4.x
 		</release>
 		<release version="1.0.4" date="2017-08-22" min="2.6.x" max="2.x.x">

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -20,7 +20,7 @@
 	</authors>
 
 	<dependencies>
-		<dependency version="2.6.x">https://github.com/DeuxHuitHuit/frontend_localisation</dependency>
+		<dependency version="2.6.x">frontend_localisation</dependency>
 	</dependencies>
 
 	<releases>

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -24,6 +24,9 @@
 	</dependencies>
 
 	<releases>
+		<release version="2.0.0" date="TBA" min="4.0.0" max="4.x.x">
+			- Update for Symphony 4.x
+		</release>
 		<release version="1.0.4" date="2017-08-22" min="2.6.x" max="2.x.x">
 			- Fix problem with default state always on
 		</release>

--- a/fields/field.multilingual_checkbox.php
+++ b/fields/field.multilingual_checkbox.php
@@ -84,7 +84,7 @@
 		public function toggleFieldData(array $data, $newState, $entry_id = null)
 		{
 			list($lc, $value) = explode(':', $newState, 2);
-			
+
 			if ($lc == 'all') {
 				foreach ($data as $key => $d) {
 					$data[$key] = $value;
@@ -329,7 +329,7 @@
 			$required = in_array('all', $required_languages) || count($langs) == count($required_languages);
 
 			if (!$required) {
-				
+
 				if (empty($required_languages)) {
 					$optional .= __('All languages are optional');
 				} else {
@@ -339,7 +339,7 @@
 							$optional_langs[] = $all_langs[$lang];
 						}
 					}
-					
+
 					foreach ($optional_langs as $idx => $lang) {
 						$optional .= ' ' . __($lang);
 						if ($idx < count($optional_langs) - 2) {
@@ -377,7 +377,7 @@
 
 			$ul = new XMLElement('ul', null, array('class' => 'tabs'));
 			foreach ($langs as $lc) {
-				$li = new XMLElement('li', $all_langs[$lc], array('class' => $lc));
+				$li = new XMLElement('li', $lc, array('class' => $lc));
 				$lc === $main_lang ? $ul->prependChild($li) : $ul->appendChild($li);
 			}
 
@@ -398,7 +398,7 @@
 				else {
 					$value = ($data["value-$lc"] === 'yes' ? 'yes' : 'no');
 				}
-				
+
 				$div = new XMLElement('div', null, array(
 					'class'          => 'tab-panel tab-' . $lc,
 					'data-lang_code' => $lc
@@ -490,7 +490,7 @@
 					"value-$lc"           => (string) $data,
 				));
 
-				// Insert values of default language as default values of the field for compatibility with other extensions 
+				// Insert values of default language as default values of the field for compatibility with other extensions
 				// that watch the values without lang code.
 				if (FLang::getMainLang() == $lc) {
 					$result = array_merge($result, array(
@@ -600,7 +600,7 @@
 			$data['value'] = $data["value-$lc"];
 			return parent::prepareTextValue($data, $entry_id);
 		}
-		
+
 		protected function getLang($data = null)
 		{
 			$required_languages = $this->getRequiredLanguages();
@@ -659,7 +659,7 @@
 			parent::buildDSRetrievalSQL($data, $joins, $multi_where, $andOperation);
 
 			$lc = FLang::getLangCode();
-			
+
 			if ($lc) {
 				$multi_where = str_replace('.value', ".`value-$lc`", $multi_where);
 			}
@@ -678,7 +678,7 @@
 		public function buildSortingSQL(&$joins, &$where, &$sort, $order = 'ASC')
 		{
 			$lc = FLang::getLangCode();
-			
+
 			if (in_array(strtolower($order), array('random', 'rand'))) {
 				$sort = 'ORDER BY RAND()';
 			}

--- a/fields/field.multilingual_checkbox.php
+++ b/fields/field.multilingual_checkbox.php
@@ -675,7 +675,7 @@
 			Sorting:
 		-------------------------------------------------------------------------*/
 
-		public function buildSortingSQL(&$joins, &$where, &$sort, $order = 'ASC')
+		public function buildSortingSQL(&$joins, &$where, &$sort, $order = 'ASC', &$select = NULL)
 		{
 			$lc = FLang::getLangCode();
 

--- a/fields/field.multilingual_checkbox.php
+++ b/fields/field.multilingual_checkbox.php
@@ -48,8 +48,6 @@
 			return Symphony::Database()
 				->create('tbl_entries_data_' . $this->get('id'))
 				->ifNotExists()
-				->charset('utf8')
-				->collate('utf8_unicode_ci')
 				->fields(array_merge([
 					'id' => [
 						'type' => 'int(11)',

--- a/fields/field.multilingual_checkbox.php
+++ b/fields/field.multilingual_checkbox.php
@@ -675,7 +675,7 @@
 			Sorting:
 		-------------------------------------------------------------------------*/
 
-		public function buildSortingSQL(&$joins, &$where, &$sort, $order = 'ASC', &$select = NULL)
+		public function buildSortingSQL(&$joins, &$where, &$sort, $order = 'ASC')
 		{
 			$lc = FLang::getLangCode();
 

--- a/fields/field.multilingual_checkbox.php
+++ b/fields/field.multilingual_checkbox.php
@@ -5,6 +5,7 @@
 	}
 
 	require_once(EXTENSIONS . '/frontend_localisation/lib/class.FLang.php');
+	require_once(EXTENSIONS . '/multilingual_checkbox_field/lib/class.entryquerymultilingualcheckboxadapter.php');
 
 	Class fieldMultilingual_CheckBox extends FieldCheckbox {
 
@@ -15,6 +16,7 @@
 		public function __construct()
 		{
 			parent::__construct();
+			$this->entryQueryFieldAdapter = new EntryQueryMultilingualCheckboxAdapter($this);
 
 			$this->_name = 'Multilingual Checkbox';
 		}

--- a/lib/class.entryquerymultilingualcheckboxadapter.php
+++ b/lib/class.entryquerymultilingualcheckboxadapter.php
@@ -3,7 +3,7 @@
 /**
  *
  */
-class EntryQueryMultilingualCheckboxAdapter extends EntryQueryTextboxAdapter
+class EntryQueryMultilingualCheckboxAdapter extends EntryQueryCheckboxAdapter
 {
     public function getFilterColumns()
     {

--- a/lib/class.entryquerymultilingualcheckboxadapter.php
+++ b/lib/class.entryquerymultilingualcheckboxadapter.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ *
+ */
+class EntryQueryMultilingualCheckboxAdapter extends EntryQueryTextboxAdapter
+{
+    public function getFilterColumns()
+    {
+        $lc = FLang::getLangCode();
+
+        if ($lc) {
+            return ['value-' . $lc];
+        }
+
+        return parent::getFilterColumns();
+    }
+
+    public function getSortColumns()
+    {
+        $lc = FLang::getLangCode();
+
+        if ($lc) {
+            return ['value-' . $lc];
+        }
+
+        return parent::getSortColumns();
+    }
+}


### PR DESCRIPTION
Update release version.
Remove unnecessary CSS.
Output only language code instead of full name.
cc @nitriques